### PR TITLE
added ability to set style on ins tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Vue.use(Ads.AutoAdsense, { adClient: 'YOUR_GOOGLE_AD_CLIENT' })
 |------------------- |------------ |--------------|---------------------------------------	|
 | root-class         | String      | `adswrapper` | Class for fill in wrapper block          |
 | ins-class          | String      | `empty`      | Class for fill in `ins` tag              |
+| ins-style          | String      | `display:block;` | Style for fill in `ins` tag          |
 | data-ad-client     | String      | `empty`      | Attribute `data-ad-client` from adsense |
 | data-ad-slot       | String      | `empty`      | Attribute `data-ad-slot` from adsense   |
 | data-ad-layout-key | String      | `empty`      | Attribute `data-ad-layout-key` from adsense |

--- a/src/ads/AdsenseComponent.vue
+++ b/src/ads/AdsenseComponent.vue
@@ -7,7 +7,7 @@
     <ins
       :class="insClass"
       class="adsbygoogle"
-      style="display:block;"
+      :style="insStyle"
       :data-ad-client="dataAdClient"
       :data-ad-slot="dataAdSlot"
       :data-ad-test="dataAdTest"

--- a/src/ads/InArticleAdsenseComponent.vue
+++ b/src/ads/InArticleAdsenseComponent.vue
@@ -7,7 +7,7 @@
     <ins
       :class="insClass"
       class="adsbygoogle"
-      style="display:block; text-align:center;"
+      :style="insStyle"
       data-ad-layout="in-article"
       :data-ad-format="dataAdFormat"
       :data-ad-client="dataAdClient"

--- a/src/ads/InFeedAdsenseComponent.vue
+++ b/src/ads/InFeedAdsenseComponent.vue
@@ -7,7 +7,7 @@
     <ins
       :class="insClass"
       class="adsbygoogle"
-      style="display:block;"
+      :style="insStyle"
       :data-ad-format="dataAdFormat"
       :data-ad-layout-key="dataAdLayoutKey"
       :data-ad-client="dataAdClient"

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -7,6 +7,10 @@ export default {
     type: String,
     default: ''
   },
+  insStyle: {
+    type: String,
+    default: 'display:block;'
+  },
   isNonPersonalizedAds: {
     type: Boolean,
     default: false


### PR DESCRIPTION
As mentioned in https://github.com/mazipan/vue-google-adsense/issues/55#issuecomment-544128358, Google is now adding a `height: auto !important;` to ins `ins` tag, making it impossible to set the height via the class alone.

When Google Adsense generates the code for Adsense, it includes the fixed size height and width inside the `style` attribute, thus this PR is required in order to use fixed size advertisements