### PR TITLE
clarified documentation regarding data-ad-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Vue.use(Ads.AutoAdsense, { adClient: 'YOUR_GOOGLE_AD_CLIENT' })
 | data-ad-slot       | String      | `empty`      | Attribute `data-ad-slot` from adsense   |
 | data-ad-layout-key | String      | `empty`      | Attribute `data-ad-layout-key` from adsense |
 | data-ad-test       | String      | `empty`      | Attribute `data-ad-test` from adsense |
-| data-ad-format     | String      | `auto`, `fluid` for InFeed and InArticle Ads | Attribute `data-ad-format` from adsense |
+| data-ad-format     | String      | `auto` for Adsense Ads<br> `fluid` for InFeed and InArticle Ads | Attribute `data-ad-format` from adsense <br> Possible values are `auto`, `horizontal`, `vertical`, `rectangle` or `fluid` |
 | data-full-width-responsive | Boolean | `false`  | Attribute `data-full-width-responsive` from adsense |
 | is-non-personalized-ads | Boolean| `false`      | Props for request `non-personalized` ads, [read more](https://support.google.com/adsense/answer/9042142?hl=en&ref_topic=7670012) |
 


### PR DESCRIPTION
You can see what the markdown table looks like on my fork: https://github.com/vesper8/vue-google-adsense