### PR TITLE
Fix non personalized ads default

### DIFF
--- a/src/ads/AdsenseComponent.vue
+++ b/src/ads/AdsenseComponent.vue
@@ -18,7 +18,7 @@
       type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
     </script2>
-    <script2 type="text/javascript">
+    <script2 v-else type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script2>
   </div>

--- a/src/ads/AdsenseComponent.vue
+++ b/src/ads/AdsenseComponent.vue
@@ -14,7 +14,7 @@
       :data-ad-format="dataAdFormat"
       :data-full-width-responsive="dataFullWidthResponsive" />
     <script2
-      v-if="isNonPersonalizedAds"
+      v-if="isNonPersonalizedAds === true || isNonPersonalizedAds === 'true'"
       type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
     </script2>

--- a/src/ads/InArticleAdsenseComponent.vue
+++ b/src/ads/InArticleAdsenseComponent.vue
@@ -19,7 +19,7 @@
       type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
     </script2>
-    <script2 type="text/javascript">
+    <script2 v-else type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script2>
   </div>

--- a/src/ads/InArticleAdsenseComponent.vue
+++ b/src/ads/InArticleAdsenseComponent.vue
@@ -15,7 +15,7 @@
       :data-ad-test="dataAdTest"
       :data-full-width-responsive="dataFullWidthResponsive" />
     <script2
-      v-if="isNonPersonalizedAds"
+      v-if="isNonPersonalizedAds === true || isNonPersonalizedAds === 'true'"
       type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
     </script2>

--- a/src/ads/InFeedAdsenseComponent.vue
+++ b/src/ads/InFeedAdsenseComponent.vue
@@ -19,7 +19,7 @@
       type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
     </script2>
-    <script2 type="text/javascript">
+    <script2 v-else type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script2>
   </div>

--- a/src/ads/InFeedAdsenseComponent.vue
+++ b/src/ads/InFeedAdsenseComponent.vue
@@ -15,7 +15,7 @@
       :data-ad-test="dataAdTest"
       :data-full-width-responsive="dataFullWidthResponsive" />
     <script2
-      v-if="isNonPersonalizedAds"
+      v-if="isNonPersonalizedAds === true || isNonPersonalizedAds === 'true'"
       type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
     </script2>


### PR DESCRIPTION
In 259b9e66f4184d0ed7b91904e2911ab919ab2024, defaults changed from `false` to `"false"`.
Now [`v-if="nonPersonalizedAds"`](https://github.com/mazipan/vue-google-adsense/blob/1.8.1/src/ads/AdsenseComponent.vue#L17) evaluates to true because`"false"` is truthy, causing #143.