### PR TITLE
fix: Non personalized ads TypeError

### DIFF
--- a/src/ads/AdsenseComponent.vue
+++ b/src/ads/AdsenseComponent.vue
@@ -16,7 +16,8 @@
     <script2
       v-if="isNonPersonalizedAds"
       type="text/javascript">
-      (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
+      (adsbygoogle = window.adsbygoogle || []).requestNonPersonalizedAds = 1;
+      (adsbygoogle = window.adsbygoogle || []).push({});
     </script2>
     <script2 type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({});

--- a/src/ads/InArticleAdsenseComponent.vue
+++ b/src/ads/InArticleAdsenseComponent.vue
@@ -17,7 +17,8 @@
     <script2
       v-if="isNonPersonalizedAds"
       type="text/javascript">
-      (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
+      (adsbygoogle = window.adsbygoogle || []).requestNonPersonalizedAds = 1;
+      (adsbygoogle = window.adsbygoogle || []).push({});
     </script2>
     <script2 type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({});

--- a/src/ads/InFeedAdsenseComponent.vue
+++ b/src/ads/InFeedAdsenseComponent.vue
@@ -17,7 +17,8 @@
     <script2
       v-if="isNonPersonalizedAds"
       type="text/javascript">
-      (adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;
+      (adsbygoogle = window.adsbygoogle || []).requestNonPersonalizedAds = 1;
+      (adsbygoogle = window.adsbygoogle || []).push({});
     </script2>
     <script2 type="text/javascript">
       (adsbygoogle = window.adsbygoogle || []).push({});


### PR DESCRIPTION
a65b8f37c498279e43f0a0681905996b9325bf56 broke non personalized ads.
[`(adsbygoogle = window.adsbygoogle || []).push({}).requestNonPersonalizedAds = 1;`](https://github.com/mazipan/vue-google-adsense/blob/b8ec3e6fa232dd2dba89de22e4fb01e10d0adc38/src/ads/AdsenseComponent.vue#L19) is not valid, because `push()` returns the length of the array ([see MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push)).
This won't show any ads for NPA users or trigger `TypeError: Cannot set property 'requestNonPersonalizedAds' of undefined` for some users.

see also https://support.google.com/adsense/answer/9042142?hl=en