### PR TITLE
Add ad-region to the fillable props

### DIFF
--- a/packages/lib/src/ads/AdsenseComponent.vue
+++ b/packages/lib/src/ads/AdsenseComponent.vue
@@ -9,6 +9,7 @@
       :data-ad-slot="dataAdSlot"
       :data-ad-test="dataAdTest"
       :data-ad-format="dataAdFormat"
+      :data-ad-region="dataAdRegion"
       :data-full-width-responsive="dataFullWidthResponsive === 'yes'"
     />
     <template v-if="isNonPersonalizedAds === 'yes'">

--- a/packages/lib/src/ads/InArticleAdsenseComponent.vue
+++ b/packages/lib/src/ads/InArticleAdsenseComponent.vue
@@ -10,6 +10,7 @@
       :data-ad-client="dataAdClient"
       :data-ad-slot="dataAdSlot"
       :data-ad-test="dataAdTest"
+      :data-ad-region="dataAdRegion"
       :data-full-width-responsive="dataFullWidthResponsive === 'yes'"
     />
     <template v-if="isNonPersonalizedAds === 'yes'">

--- a/packages/lib/src/ads/InFeedAdsenseComponent.vue
+++ b/packages/lib/src/ads/InFeedAdsenseComponent.vue
@@ -10,6 +10,7 @@
       :data-ad-client="dataAdClient"
       :data-ad-slot="dataAdSlot"
       :data-ad-test="dataAdTest"
+      :data-ad-region="dataAdRegion"
       :data-full-width-responsive="dataFullWidthResponsive === 'yes'"
     />
     <template v-if="isNonPersonalizedAds === 'yes'">

--- a/packages/lib/src/utils/props.ts
+++ b/packages/lib/src/utils/props.ts
@@ -38,5 +38,9 @@ export default {
   dataFullWidthResponsive: {
     type: String,
     default: 'no'
-  }
+  },
+  dataAdRegion: {
+    type: String,
+    default: ''
+  },
 }


### PR DESCRIPTION
## 👋 Thank you for the PR!

### Description:

This PR adds the functionality to specify ad-region in adsense ads, because of the SPA background, if a route changes, new ads won't load. If you add a random value every route change to this ad-region, it will display an ad.

### Minimum Support

- [ ] Click 🌟 button to this repo
- [ ] Follow the Author

### Consider to Support

- 👉 🇮🇩 [Trakteer](https://trakteer.id/mazipan?utm_source=github)
- 👉 🌍 [BuyMeACoffe](https://www.buymeacoffee.com/mazipan?utm_source=github)
- 👉 🌍 [Paypal](https://www.paypal.me/mazipan?utm_source=github)
- 👉 🌍 [Ko-Fi](https://ko-fi.com/mazipan)
